### PR TITLE
feat(benchmark): synthetic harness and regression corpus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ test-results
 .rts2_cache_*
 .rts2_cache
 *.tsbuildinfo
+benchmark-results.json

--- a/benchmark/cli.ts
+++ b/benchmark/cli.ts
@@ -1,0 +1,11 @@
+import { buildReport, printSummary, writeReport } from './report.js';
+import { runBenchmark } from './runner.js';
+
+const result = await runBenchmark();
+const report = buildReport(result);
+printSummary(report);
+await writeReport(report);
+
+if (result.decodeRate < 1) {
+  process.exit(1);
+}

--- a/benchmark/cli.ts
+++ b/benchmark/cli.ts
@@ -4,8 +4,15 @@ import { runBenchmark } from './runner.js';
 const result = await runBenchmark();
 const report = buildReport(result);
 printSummary(report);
-await writeReport(report);
 
-if (result.decodeRate < 1 || result.falsePositiveRate > 0) {
+const shouldFail = report.decodeRate < 1 || report.falsePositiveRate > 0;
+
+try {
+  await writeReport(report);
+} catch (error) {
+  process.stderr.write(`Warning: failed to write benchmark-results.json: ${error}\n`);
+}
+
+if (shouldFail) {
   process.exit(1);
 }

--- a/benchmark/cli.ts
+++ b/benchmark/cli.ts
@@ -6,6 +6,6 @@ const report = buildReport(result);
 printSummary(report);
 await writeReport(report);
 
-if (result.decodeRate < 1) {
+if (result.decodeRate < 1 || result.falsePositiveRate > 0) {
   process.exit(1);
 }

--- a/benchmark/corpus/generate.ts
+++ b/benchmark/corpus/generate.ts
@@ -207,8 +207,9 @@ export function buildQrGrid(
     const pos = FORMAT_INFO_FIRST_COPY_POSITIONS[index];
     if (pos) setModule(matrix, pos[0], pos[1], ((formatBits >> (14 - index)) & 1) === 1);
   }
-  for (let index = 0; index < getFormatInfoSecondCopyPositions(size).length; index += 1) {
-    const pos = getFormatInfoSecondCopyPositions(size)[index];
+  const secondCopyPositions = getFormatInfoSecondCopyPositions(size);
+  for (let index = 0; index < secondCopyPositions.length; index += 1) {
+    const pos = secondCopyPositions[index];
     if (pos) setModule(matrix, pos[0], pos[1], ((formatBits >> (14 - index)) & 1) === 1);
   }
 

--- a/benchmark/corpus/generate.ts
+++ b/benchmark/corpus/generate.ts
@@ -1,0 +1,376 @@
+import {
+  buildDataModulePositions,
+  buildFormatInfoCodeword,
+  buildFunctionModuleMask,
+  buildVersionInfoCodeword,
+  getRemainderBits,
+  getVersionBlockInfo,
+  maskApplies,
+  type QrErrorCorrectionLevel,
+} from '../../src/internal/qr-spec.js';
+import { ALIGNMENT_PATTERN_CENTERS } from '../../src/internal/qr-tables.js';
+import { rsEncode } from '../../src/internal/reed-solomon.js';
+import type { Ecl, PositiveEntry } from './index.js';
+
+// ─── Bit helpers ──────────────────────────────────────────────────────────────
+
+function appendBits(bits: number[], value: number, length: number): void {
+  for (let bit = length - 1; bit >= 0; bit -= 1) {
+    bits.push((value >> bit) & 1);
+  }
+}
+
+function bytesFromBits(bits: readonly number[]): number[] {
+  const bytes: number[] = [];
+  for (let index = 0; index < bits.length; index += 8) {
+    let value = 0;
+    for (let bit = 0; bit < 8; bit += 1) {
+      value = (value << 1) | (bits[index + bit] ?? 0);
+    }
+    bytes.push(value);
+  }
+  return bytes;
+}
+
+// ─── Payload encoding ─────────────────────────────────────────────────────────
+
+/**
+ * Encodes a short message in byte mode and pads to the full data capacity for
+ * the given version/ECL combination.
+ */
+function encodeByteMode(message: string, version: number, totalDataCodewords: number): number[] {
+  const messageBytes = new TextEncoder().encode(message);
+  const countBits = version <= 9 ? 8 : 16;
+  const bits: number[] = [];
+
+  appendBits(bits, 0b0100, 4); // byte mode
+  appendBits(bits, messageBytes.length, countBits);
+  for (const byte of messageBytes) {
+    appendBits(bits, byte, 8);
+  }
+
+  const totalBits = totalDataCodewords * 8;
+  appendBits(bits, 0, Math.min(4, totalBits - bits.length));
+  while (bits.length % 8 !== 0) bits.push(0);
+
+  let padByte = 0xec;
+  while (bits.length < totalBits) {
+    appendBits(bits, padByte, 8);
+    padByte = padByte === 0xec ? 0x11 : 0xec;
+  }
+
+  return bytesFromBits(bits);
+}
+
+// ─── RS block interleaving ────────────────────────────────────────────────────
+
+/**
+ * Splits data codewords into RS blocks, encodes each block, then interleaves
+ * data and EC codewords in the order required by ISO 18004.
+ */
+function interleaveBlocks(
+  dataCodewords: readonly number[],
+  blockInfo: ReturnType<typeof getVersionBlockInfo>,
+): number[] {
+  // Build block data arrays following group structure
+  const blocks: Array<{ data: number[]; ecc: number[] }> = [];
+  for (const group of blockInfo.groups) {
+    for (let repeat = 0; repeat < group.count; repeat += 1) {
+      blocks.push({ data: new Array<number>(group.dataCodewords).fill(0), ecc: [] });
+    }
+  }
+
+  // Fill blocks with consecutive data codewords
+  let offset = 0;
+  for (const block of blocks) {
+    for (let index = 0; index < block.data.length; index += 1) {
+      block.data[index] = dataCodewords[offset] ?? 0;
+      offset += 1;
+    }
+  }
+
+  // RS-encode each block
+  for (const block of blocks) {
+    block.ecc = Array.from(rsEncode(block.data, blockInfo.ecCodewordsPerBlock));
+  }
+
+  // Interleave data codewords
+  const maxDataLen = Math.max(...blocks.map((b) => b.data.length));
+  const raw: number[] = [];
+  for (let index = 0; index < maxDataLen; index += 1) {
+    for (const block of blocks) {
+      if (index < block.data.length) raw.push(block.data[index] ?? 0);
+    }
+  }
+
+  // Interleave EC codewords
+  for (let index = 0; index < blockInfo.ecCodewordsPerBlock; index += 1) {
+    for (const block of blocks) {
+      raw.push(block.ecc[index] ?? 0);
+    }
+  }
+
+  return raw;
+}
+
+// ─── Matrix helpers ───────────────────────────────────────────────────────────
+
+const FORMAT_INFO_FIRST_COPY: readonly (readonly [number, number])[] = [
+  [8, 0],
+  [8, 1],
+  [8, 2],
+  [8, 3],
+  [8, 4],
+  [8, 5],
+  [8, 7],
+  [8, 8],
+  [7, 8],
+  [5, 8],
+  [4, 8],
+  [3, 8],
+  [2, 8],
+  [1, 8],
+  [0, 8],
+];
+
+function formatInfoSecondCopy(size: number): readonly (readonly [number, number])[] {
+  return [
+    [8, size - 1],
+    [8, size - 2],
+    [8, size - 3],
+    [8, size - 4],
+    [8, size - 5],
+    [8, size - 6],
+    [8, size - 7],
+    [8, size - 8],
+    [size - 7, 8],
+    [size - 6, 8],
+    [size - 5, 8],
+    [size - 4, 8],
+    [size - 3, 8],
+    [size - 2, 8],
+    [size - 1, 8],
+  ];
+}
+
+function setModule(matrix: boolean[][], row: number, col: number, value: boolean): void {
+  const currentRow = matrix[row];
+  if (currentRow !== undefined && currentRow[col] !== undefined) {
+    currentRow[col] = value;
+  }
+}
+
+function drawFinder(matrix: boolean[][], top: number, left: number): void {
+  for (let row = 0; row < 7; row += 1) {
+    for (let col = 0; col < 7; col += 1) {
+      const dark =
+        row === 0 ||
+        row === 6 ||
+        col === 0 ||
+        col === 6 ||
+        (row >= 2 && row <= 4 && col >= 2 && col <= 4);
+      setModule(matrix, top + row, left + col, dark);
+    }
+  }
+}
+
+function drawAlignment(matrix: boolean[][], centerRow: number, centerCol: number): void {
+  for (let row = -2; row <= 2; row += 1) {
+    for (let col = -2; col <= 2; col += 1) {
+      const dark = Math.abs(row) === 2 || Math.abs(col) === 2 || (row === 0 && col === 0);
+      setModule(matrix, centerRow + row, centerCol + col, dark);
+    }
+  }
+}
+
+// ─── Full grid builder ────────────────────────────────────────────────────────
+
+/**
+ * Builds a fully-compliant QR matrix for any version 1-40, EC level, mask
+ * pattern, and short byte-mode message.  All function modules, format info,
+ * version info, and interleaved RS codewords are placed per ISO 18004.
+ */
+export function buildQrGrid(
+  version: number,
+  ecl: Ecl,
+  maskPattern: number,
+  message: string,
+): boolean[][] {
+  const size = 17 + version * 4;
+  const blockInfo = getVersionBlockInfo(version, ecl as QrErrorCorrectionLevel);
+  const dataCodewords = encodeByteMode(message, version, blockInfo.dataCodewords);
+  const rawCodewords = interleaveBlocks(dataCodewords, blockInfo);
+  const reserved = buildFunctionModuleMask(size, version);
+
+  const matrix: boolean[][] = Array.from({ length: size }, () =>
+    Array.from({ length: size }, () => false),
+  );
+
+  // Finder patterns
+  drawFinder(matrix, 0, 0);
+  drawFinder(matrix, 0, size - 7);
+  drawFinder(matrix, size - 7, 0);
+
+  // Timing patterns
+  for (let index = 8; index < size - 8; index += 1) {
+    setModule(matrix, 6, index, index % 2 === 0);
+    setModule(matrix, index, 6, index % 2 === 0);
+  }
+
+  // Alignment patterns (version 2+)
+  const centers = ALIGNMENT_PATTERN_CENTERS[version - 1] ?? [];
+  for (const rowCenter of centers) {
+    for (const colCenter of centers) {
+      if (
+        (rowCenter === 6 && colCenter === 6) ||
+        (rowCenter === 6 && colCenter === size - 7) ||
+        (rowCenter === size - 7 && colCenter === 6)
+      ) {
+        continue;
+      }
+      drawAlignment(matrix, rowCenter, colCenter);
+    }
+  }
+
+  // Dark module
+  setModule(matrix, size - 8, 8, true);
+
+  // Format info (both copies)
+  const formatBits = buildFormatInfoCodeword(ecl as QrErrorCorrectionLevel, maskPattern);
+  for (let index = 0; index < FORMAT_INFO_FIRST_COPY.length; index += 1) {
+    const pos = FORMAT_INFO_FIRST_COPY[index];
+    if (pos) setModule(matrix, pos[0], pos[1], ((formatBits >> (14 - index)) & 1) === 1);
+  }
+  const secondCopy = formatInfoSecondCopy(size);
+  for (let index = 0; index < secondCopy.length; index += 1) {
+    const pos = secondCopy[index];
+    if (pos) setModule(matrix, pos[0], pos[1], ((formatBits >> (14 - index)) & 1) === 1);
+  }
+
+  // Version info (version 7+)
+  if (version >= 7) {
+    const versionBits = buildVersionInfoCodeword(version);
+    const topRight = Array.from(
+      { length: 18 },
+      (_, index) => [Math.floor(index / 3), size - 11 + (index % 3)] as const,
+    );
+    const bottomLeft = Array.from(
+      { length: 18 },
+      (_, index) => [size - 11 + (index % 3), Math.floor(index / 3)] as const,
+    );
+    for (let index = 0; index < 18; index += 1) {
+      const bit = ((versionBits >> (17 - index)) & 1) === 1;
+      const tr = topRight[index];
+      const bl = bottomLeft[index];
+      if (tr) setModule(matrix, tr[0], tr[1], bit);
+      if (bl) setModule(matrix, bl[0], bl[1], bit);
+    }
+  }
+
+  // Data bits
+  const positions = buildDataModulePositions(size, reserved);
+  const rawBits: number[] = [];
+  for (const codeword of rawCodewords) {
+    for (let bit = 7; bit >= 0; bit -= 1) {
+      rawBits.push((codeword >> bit) & 1);
+    }
+  }
+  const remainder = getRemainderBits(version);
+  for (let index = 0; index < remainder; index += 1) {
+    rawBits.push(0);
+  }
+
+  for (let index = 0; index < positions.length; index += 1) {
+    const pos = positions[index];
+    if (!pos) continue;
+    const [row, col] = pos;
+    const bit = rawBits[index] === 1;
+    setModule(matrix, row, col, maskApplies(maskPattern, row, col) ? !bit : bit);
+  }
+
+  return matrix;
+}
+
+// ─── RS error-injection helper ────────────────────────────────────────────────
+
+/**
+ * Returns a copy of the grid with the most-significant bit of the first
+ * `errorCount` data codewords flipped.  For v1-M: t = floor(10/2) = 5;
+ * injecting 4 errors stays within the correction capacity.
+ */
+export function injectRsErrors(
+  grid: boolean[][],
+  version: number,
+  _ecl: Ecl,
+  errorCount: number,
+): boolean[][] {
+  const size = grid.length;
+  const reserved = buildFunctionModuleMask(size, version);
+  const positions = buildDataModulePositions(size, reserved);
+  const corrupted = grid.map((row) => row.slice());
+
+  for (let codeword = 0; codeword < errorCount; codeword += 1) {
+    // Flip the most-significant bit (bit 7) of each codeword
+    const pos = positions[codeword * 8];
+    if (!pos) continue;
+    const [row, col] = pos;
+    const currentRow = corrupted[row];
+    if (currentRow) currentRow[col] = !currentRow[col];
+  }
+
+  return corrupted;
+}
+
+// ─── Corpus generation ────────────────────────────────────────────────────────
+
+const ECL_LEVELS: readonly Ecl[] = ['L', 'M', 'Q', 'H'];
+const BENCHMARK_MESSAGE = 'HI';
+
+export function generatePositiveCorpus(): PositiveEntry[] {
+  const entries: PositiveEntry[] = [];
+
+  // v1: all 4 EC levels × all 8 masks
+  for (const ecl of ECL_LEVELS) {
+    for (let mask = 0; mask < 8; mask += 1) {
+      entries.push({
+        id: `v1-${ecl}-m${mask}`,
+        version: 1,
+        ecl,
+        maskPattern: mask,
+        message: BENCHMARK_MESSAGE,
+        rsErrorsInjected: false,
+        grid: buildQrGrid(1, ecl, mask, BENCHMARK_MESSAGE),
+      });
+    }
+  }
+
+  // v7, v20, v40: all 4 EC levels, mask 0
+  for (const version of [7, 20, 40] as const) {
+    for (const ecl of ECL_LEVELS) {
+      entries.push({
+        id: `v${version}-${ecl}-m0`,
+        version,
+        ecl,
+        maskPattern: 0,
+        message: BENCHMARK_MESSAGE,
+        rsErrorsInjected: false,
+        grid: buildQrGrid(version, ecl, 0, BENCHMARK_MESSAGE),
+      });
+    }
+  }
+
+  // RS error-correction fixture: v1-M with 4 corrupted data codewords (t=5)
+  const baseGrid = buildQrGrid(1, 'M', 0, BENCHMARK_MESSAGE);
+  const corruptedGrid = injectRsErrors(baseGrid, 1, 'M', 4);
+  entries.push({
+    id: 'v1-M-m0-rs-corrected',
+    version: 1,
+    ecl: 'M',
+    maskPattern: 0,
+    message: BENCHMARK_MESSAGE,
+    rsErrorsInjected: true,
+    grid: corruptedGrid,
+  });
+
+  return entries;
+}

--- a/benchmark/corpus/generate.ts
+++ b/benchmark/corpus/generate.ts
@@ -3,8 +3,12 @@ import {
   buildFormatInfoCodeword,
   buildFunctionModuleMask,
   buildVersionInfoCodeword,
+  FORMAT_INFO_FIRST_COPY_POSITIONS,
+  getFormatInfoSecondCopyPositions,
   getRemainderBits,
   getVersionBlockInfo,
+  getVersionInfoFirstCopyPositions,
+  getVersionInfoSecondCopyPositions,
   maskApplies,
   type QrErrorCorrectionLevel,
 } from '../../src/internal/qr-spec.js';
@@ -115,44 +119,6 @@ function interleaveBlocks(
 
 // ─── Matrix helpers ───────────────────────────────────────────────────────────
 
-const FORMAT_INFO_FIRST_COPY: readonly (readonly [number, number])[] = [
-  [8, 0],
-  [8, 1],
-  [8, 2],
-  [8, 3],
-  [8, 4],
-  [8, 5],
-  [8, 7],
-  [8, 8],
-  [7, 8],
-  [5, 8],
-  [4, 8],
-  [3, 8],
-  [2, 8],
-  [1, 8],
-  [0, 8],
-];
-
-function formatInfoSecondCopy(size: number): readonly (readonly [number, number])[] {
-  return [
-    [8, size - 1],
-    [8, size - 2],
-    [8, size - 3],
-    [8, size - 4],
-    [8, size - 5],
-    [8, size - 6],
-    [8, size - 7],
-    [8, size - 8],
-    [size - 7, 8],
-    [size - 6, 8],
-    [size - 5, 8],
-    [size - 4, 8],
-    [size - 3, 8],
-    [size - 2, 8],
-    [size - 1, 8],
-  ];
-}
-
 function setModule(matrix: boolean[][], row: number, col: number, value: boolean): void {
   const currentRow = matrix[row];
   if (currentRow !== undefined && currentRow[col] !== undefined) {
@@ -237,27 +203,20 @@ export function buildQrGrid(
 
   // Format info (both copies)
   const formatBits = buildFormatInfoCodeword(ecl as QrErrorCorrectionLevel, maskPattern);
-  for (let index = 0; index < FORMAT_INFO_FIRST_COPY.length; index += 1) {
-    const pos = FORMAT_INFO_FIRST_COPY[index];
+  for (let index = 0; index < FORMAT_INFO_FIRST_COPY_POSITIONS.length; index += 1) {
+    const pos = FORMAT_INFO_FIRST_COPY_POSITIONS[index];
     if (pos) setModule(matrix, pos[0], pos[1], ((formatBits >> (14 - index)) & 1) === 1);
   }
-  const secondCopy = formatInfoSecondCopy(size);
-  for (let index = 0; index < secondCopy.length; index += 1) {
-    const pos = secondCopy[index];
+  for (let index = 0; index < getFormatInfoSecondCopyPositions(size).length; index += 1) {
+    const pos = getFormatInfoSecondCopyPositions(size)[index];
     if (pos) setModule(matrix, pos[0], pos[1], ((formatBits >> (14 - index)) & 1) === 1);
   }
 
   // Version info (version 7+)
   if (version >= 7) {
     const versionBits = buildVersionInfoCodeword(version);
-    const topRight = Array.from(
-      { length: 18 },
-      (_, index) => [Math.floor(index / 3), size - 11 + (index % 3)] as const,
-    );
-    const bottomLeft = Array.from(
-      { length: 18 },
-      (_, index) => [size - 11 + (index % 3), Math.floor(index / 3)] as const,
-    );
+    const topRight = getVersionInfoFirstCopyPositions(size);
+    const bottomLeft = getVersionInfoSecondCopyPositions(size);
     for (let index = 0; index < 18; index += 1) {
       const bit = ((versionBits >> (17 - index)) & 1) === 1;
       const tr = topRight[index];

--- a/benchmark/corpus/index.ts
+++ b/benchmark/corpus/index.ts
@@ -1,0 +1,23 @@
+export type Ecl = 'L' | 'M' | 'Q' | 'H';
+
+export interface PositiveEntry {
+  readonly id: string;
+  readonly version: number;
+  readonly ecl: Ecl;
+  readonly maskPattern: number;
+  readonly message: string;
+  /** True when bits were deliberately flipped to exercise RS error correction. */
+  readonly rsErrorsInjected: boolean;
+  readonly grid: boolean[][];
+}
+
+export interface NegativeEntry {
+  readonly id: string;
+  readonly kind: 'random-noise' | 'scrambled-data' | 'near-miss-format';
+  readonly grid: boolean[][];
+}
+
+export interface BenchmarkCorpus {
+  readonly positives: readonly PositiveEntry[];
+  readonly negatives: readonly NegativeEntry[];
+}

--- a/benchmark/corpus/negatives.ts
+++ b/benchmark/corpus/negatives.ts
@@ -114,8 +114,9 @@ function nearMissFormatGrid(version: number, ecl: Ecl): boolean[][] {
     const pos = FORMAT_INFO_FIRST_COPY_POSITIONS[index];
     if (pos) setModule(grid, pos[0], pos[1], ((corrupt >> (14 - index)) & 1) === 1);
   }
-  for (let index = 0; index < getFormatInfoSecondCopyPositions(size).length; index += 1) {
-    const pos = getFormatInfoSecondCopyPositions(size)[index];
+  const secondCopyPositions = getFormatInfoSecondCopyPositions(size);
+  for (let index = 0; index < secondCopyPositions.length; index += 1) {
+    const pos = secondCopyPositions[index];
     if (pos) setModule(grid, pos[0], pos[1], ((corrupt >> (14 - index)) & 1) === 1);
   }
 

--- a/benchmark/corpus/negatives.ts
+++ b/benchmark/corpus/negatives.ts
@@ -2,6 +2,8 @@ import {
   buildDataModulePositions,
   buildFormatInfoCodeword,
   buildFunctionModuleMask,
+  FORMAT_INFO_FIRST_COPY_POSITIONS,
+  getFormatInfoSecondCopyPositions,
   type QrErrorCorrectionLevel,
 } from '../../src/internal/qr-spec.js';
 import { buildQrGrid } from './generate.js';
@@ -65,44 +67,6 @@ function findCorruptFormatInfo(): number {
 
 const CORRUPT_FORMAT_INFO = findCorruptFormatInfo();
 
-const FORMAT_INFO_FIRST_COPY: readonly (readonly [number, number])[] = [
-  [8, 0],
-  [8, 1],
-  [8, 2],
-  [8, 3],
-  [8, 4],
-  [8, 5],
-  [8, 7],
-  [8, 8],
-  [7, 8],
-  [5, 8],
-  [4, 8],
-  [3, 8],
-  [2, 8],
-  [1, 8],
-  [0, 8],
-];
-
-function formatInfoSecondCopy(size: number): readonly (readonly [number, number])[] {
-  return [
-    [8, size - 1],
-    [8, size - 2],
-    [8, size - 3],
-    [8, size - 4],
-    [8, size - 5],
-    [8, size - 6],
-    [8, size - 7],
-    [8, size - 8],
-    [size - 7, 8],
-    [size - 6, 8],
-    [size - 5, 8],
-    [size - 4, 8],
-    [size - 3, 8],
-    [size - 2, 8],
-    [size - 1, 8],
-  ];
-}
-
 function setModule(matrix: boolean[][], row: number, col: number, value: boolean): void {
   const currentRow = matrix[row];
   if (currentRow !== undefined && currentRow[col] !== undefined) {
@@ -146,13 +110,12 @@ function nearMissFormatGrid(version: number, ecl: Ecl): boolean[][] {
   const size = grid.length;
   const corrupt = CORRUPT_FORMAT_INFO;
 
-  for (let index = 0; index < FORMAT_INFO_FIRST_COPY.length; index += 1) {
-    const pos = FORMAT_INFO_FIRST_COPY[index];
+  for (let index = 0; index < FORMAT_INFO_FIRST_COPY_POSITIONS.length; index += 1) {
+    const pos = FORMAT_INFO_FIRST_COPY_POSITIONS[index];
     if (pos) setModule(grid, pos[0], pos[1], ((corrupt >> (14 - index)) & 1) === 1);
   }
-  const secondCopy = formatInfoSecondCopy(size);
-  for (let index = 0; index < secondCopy.length; index += 1) {
-    const pos = secondCopy[index];
+  for (let index = 0; index < getFormatInfoSecondCopyPositions(size).length; index += 1) {
+    const pos = getFormatInfoSecondCopyPositions(size)[index];
     if (pos) setModule(grid, pos[0], pos[1], ((corrupt >> (14 - index)) & 1) === 1);
   }
 

--- a/benchmark/corpus/negatives.ts
+++ b/benchmark/corpus/negatives.ts
@@ -1,0 +1,212 @@
+import {
+  buildDataModulePositions,
+  buildFormatInfoCodeword,
+  buildFunctionModuleMask,
+  type QrErrorCorrectionLevel,
+} from '../../src/internal/qr-spec.js';
+import { buildQrGrid } from './generate.js';
+import type { Ecl, NegativeEntry } from './index.js';
+
+// ─── Deterministic PRNG ───────────────────────────────────────────────────────
+
+/** Mulberry32 — fast, seedable 32-bit PRNG. */
+function makePrng(seed: number): () => number {
+  let state = seed;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let z = state;
+    z = Math.imul(z ^ (z >>> 15), z | 1);
+    z ^= z + Math.imul(z ^ (z >>> 7), z | 61);
+    return ((z ^ (z >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// ─── Format-info corruption helper ───────────────────────────────────────────
+
+/**
+ * Returns a 15-bit value whose Hamming distance from every valid format-info
+ * codeword exceeds 3, guaranteeing that decodeFormatInfo will throw.
+ *
+ * The BCH(15,5) format-info code has minimum distance 7, so the 32 valid
+ * codewords each occupy a Hamming ball of radius 3.  We search the space for
+ * the first candidate (starting from 0x1234) that lies outside all balls.
+ */
+function findCorruptFormatInfo(): number {
+  const valid = new Set<number>();
+  for (const ecl of ['L', 'M', 'Q', 'H'] as const) {
+    for (let mask = 0; mask < 8; mask += 1) {
+      valid.add(buildFormatInfoCodeword(ecl as QrErrorCorrectionLevel, mask));
+    }
+  }
+
+  const validArray = Array.from(valid);
+
+  function minDistance(candidate: number): number {
+    let min = 15;
+    for (const v of validArray) {
+      let dist = 0;
+      let xor = candidate ^ v;
+      while (xor !== 0) {
+        dist += xor & 1;
+        xor >>>= 1;
+      }
+      if (dist < min) min = dist;
+    }
+    return min;
+  }
+
+  for (let candidate = 0x0000; candidate <= 0x7fff; candidate += 1) {
+    if (minDistance(candidate) > 3) return candidate;
+  }
+
+  // Unreachable: there are thousands of valid candidates in a 32768-word space.
+  throw new Error('Could not find corrupt format-info value.');
+}
+
+const CORRUPT_FORMAT_INFO = findCorruptFormatInfo();
+
+const FORMAT_INFO_FIRST_COPY: readonly (readonly [number, number])[] = [
+  [8, 0],
+  [8, 1],
+  [8, 2],
+  [8, 3],
+  [8, 4],
+  [8, 5],
+  [8, 7],
+  [8, 8],
+  [7, 8],
+  [5, 8],
+  [4, 8],
+  [3, 8],
+  [2, 8],
+  [1, 8],
+  [0, 8],
+];
+
+function formatInfoSecondCopy(size: number): readonly (readonly [number, number])[] {
+  return [
+    [8, size - 1],
+    [8, size - 2],
+    [8, size - 3],
+    [8, size - 4],
+    [8, size - 5],
+    [8, size - 6],
+    [8, size - 7],
+    [8, size - 8],
+    [size - 7, 8],
+    [size - 6, 8],
+    [size - 5, 8],
+    [size - 4, 8],
+    [size - 3, 8],
+    [size - 2, 8],
+    [size - 1, 8],
+  ];
+}
+
+function setModule(matrix: boolean[][], row: number, col: number, value: boolean): void {
+  const currentRow = matrix[row];
+  if (currentRow !== undefined && currentRow[col] !== undefined) {
+    currentRow[col] = value;
+  }
+}
+
+// ─── Negative corpus generators ───────────────────────────────────────────────
+
+/** Fills a grid with random boolean values. */
+function randomNoiseGrid(size: number, seed: number): boolean[][] {
+  const rng = makePrng(seed);
+  return Array.from({ length: size }, () => Array.from({ length: size }, () => rng() < 0.5));
+}
+
+/**
+ * Builds a QR-shaped grid (correct function modules) but randomises every data
+ * module so RS decoding will almost certainly fail.
+ */
+function scrambledDataGrid(version: number, ecl: Ecl, seed: number): boolean[][] {
+  const grid = buildQrGrid(version, ecl, 0, 'HI');
+  const size = grid.length;
+  const reserved = buildFunctionModuleMask(size, version);
+  const positions = buildDataModulePositions(size, reserved);
+  const rng = makePrng(seed);
+
+  for (const [row, col] of positions) {
+    const currentRow = grid[row];
+    if (currentRow) currentRow[col] = rng() < 0.5;
+  }
+
+  return grid;
+}
+
+/**
+ * Builds a QR-shaped grid with valid structure but a corrupt format-info field
+ * in BOTH copies, causing decodeFormatInfo to throw.
+ */
+function nearMissFormatGrid(version: number, ecl: Ecl): boolean[][] {
+  const grid = buildQrGrid(version, ecl, 0, 'HI');
+  const size = grid.length;
+  const corrupt = CORRUPT_FORMAT_INFO;
+
+  for (let index = 0; index < FORMAT_INFO_FIRST_COPY.length; index += 1) {
+    const pos = FORMAT_INFO_FIRST_COPY[index];
+    if (pos) setModule(grid, pos[0], pos[1], ((corrupt >> (14 - index)) & 1) === 1);
+  }
+  const secondCopy = formatInfoSecondCopy(size);
+  for (let index = 0; index < secondCopy.length; index += 1) {
+    const pos = secondCopy[index];
+    if (pos) setModule(grid, pos[0], pos[1], ((corrupt >> (14 - index)) & 1) === 1);
+  }
+
+  return grid;
+}
+
+// ─── Public factory ───────────────────────────────────────────────────────────
+
+export function generateNegativeCorpus(): NegativeEntry[] {
+  const entries: NegativeEntry[] = [];
+
+  // Random noise grids at QR-like sizes (v1=21, v7=45, v20=97, v40=177)
+  for (const [version, seed] of [
+    [1, 0xdead],
+    [7, 0xbeef],
+    [20, 0xcafe],
+    [40, 0xf00d],
+    [1, 0x1234],
+    [7, 0x5678],
+  ] as const) {
+    const size = 17 + version * 4;
+    entries.push({
+      id: `noise-v${version}-${seed.toString(16)}`,
+      kind: 'random-noise',
+      grid: randomNoiseGrid(size, seed),
+    });
+  }
+
+  // Scrambled data (valid shape, garbage data) for several version/ECL combos
+  for (const [version, ecl, seed] of [
+    [1, 'M', 0xaaaa],
+    [7, 'M', 0xbbbb],
+    [20, 'L', 0xcccc],
+    [40, 'H', 0xdddd],
+  ] as const) {
+    entries.push({
+      id: `scrambled-v${version}-${ecl}`,
+      kind: 'scrambled-data',
+      grid: scrambledDataGrid(version, ecl as Ecl, seed),
+    });
+  }
+
+  // Near-miss format-info (valid QR structure, corrupt format info)
+  for (const [version, ecl] of [
+    [1, 'M'],
+    [7, 'L'],
+    [20, 'H'],
+  ] as const) {
+    entries.push({
+      id: `near-miss-fmt-v${version}-${ecl}`,
+      kind: 'near-miss-format',
+      grid: nearMissFormatGrid(version, ecl as Ecl),
+    });
+  }
+
+  return entries;
+}

--- a/benchmark/corpus/negatives.ts
+++ b/benchmark/corpus/negatives.ts
@@ -29,7 +29,7 @@ function makePrng(seed: number): () => number {
  *
  * The BCH(15,5) format-info code has minimum distance 7, so the 32 valid
  * codewords each occupy a Hamming ball of radius 3.  We search the space for
- * the first candidate (starting from 0x1234) that lies outside all balls.
+ * the first candidate (starting from 0x0000) that lies outside all balls.
  */
 function findCorruptFormatInfo(): number {
   const valid = new Set<number>();

--- a/benchmark/report.ts
+++ b/benchmark/report.ts
@@ -1,0 +1,54 @@
+import type { BenchmarkResult } from './runner.js';
+
+const OUTPUT_FILE = `${import.meta.dirname}/../benchmark-results.json`;
+
+export interface BenchmarkReport {
+  readonly timestamp: string;
+  readonly positiveCount: number;
+  readonly negativeCount: number;
+  readonly decodeSuccesses: number;
+  readonly decodeFailures: number;
+  readonly falsePositives: number;
+  readonly decodeRate: number;
+  readonly falsePositiveRate: number;
+  readonly failedIds: readonly string[];
+  readonly falsePositiveIds: readonly string[];
+}
+
+export function buildReport(result: BenchmarkResult): BenchmarkReport {
+  return {
+    timestamp: new Date().toISOString(),
+    positiveCount: result.positives.length,
+    negativeCount: result.negatives.length,
+    decodeSuccesses: result.decodeSuccesses,
+    decodeFailures: result.decodeFailures,
+    falsePositives: result.falsePositives,
+    decodeRate: result.decodeRate,
+    falsePositiveRate: result.falsePositiveRate,
+    failedIds: result.positives.filter((r) => !r.passed).map((r) => r.entry.id),
+    falsePositiveIds: result.negatives.filter((r) => r.falsePositive).map((r) => r.entry.id),
+  };
+}
+
+export function printSummary(report: BenchmarkReport): void {
+  const pct = (n: number) => `${(n * 100).toFixed(1)}%`;
+  console.log('\n── Benchmark Results ──────────────────────────────────');
+  console.log(
+    `  Positives : ${report.decodeSuccesses}/${report.positiveCount} passed  (decodeRate ${pct(report.decodeRate)})`,
+  );
+  console.log(
+    `  Negatives : ${report.falsePositives} false positives out of ${report.negativeCount}  (falsePositiveRate ${pct(report.falsePositiveRate)})`,
+  );
+  if (report.failedIds.length > 0) {
+    console.log(`  Failed    : ${report.failedIds.join(', ')}`);
+  }
+  if (report.falsePositiveIds.length > 0) {
+    console.log(`  FP ids    : ${report.falsePositiveIds.join(', ')}`);
+  }
+  console.log(`  Output    : ${OUTPUT_FILE}`);
+  console.log('───────────────────────────────────────────────────────\n');
+}
+
+export async function writeReport(report: BenchmarkReport): Promise<void> {
+  await Bun.write(OUTPUT_FILE, `${JSON.stringify(report, null, 2)}\n`);
+}

--- a/benchmark/runner.ts
+++ b/benchmark/runner.ts
@@ -1,0 +1,85 @@
+import { decodeGrid } from '../src/index.js';
+import { generatePositiveCorpus } from './corpus/generate.js';
+import type { NegativeEntry, PositiveEntry } from './corpus/index.js';
+import { generateNegativeCorpus } from './corpus/negatives.js';
+
+// ─── Result types ─────────────────────────────────────────────────────────────
+
+export interface PositiveResult {
+  readonly entry: PositiveEntry;
+  readonly passed: boolean;
+  readonly decodedText: string | null;
+  readonly error: string | null;
+}
+
+export interface NegativeResult {
+  readonly entry: NegativeEntry;
+  /** True when decodeGrid unexpectedly succeeded (false positive). */
+  readonly falsePositive: boolean;
+  readonly decodedText: string | null;
+}
+
+export interface BenchmarkResult {
+  readonly positives: readonly PositiveResult[];
+  readonly negatives: readonly NegativeResult[];
+  readonly decodeSuccesses: number;
+  readonly decodeFailures: number;
+  readonly falsePositives: number;
+  readonly decodeRate: number;
+  readonly falsePositiveRate: number;
+}
+
+// ─── Runner ───────────────────────────────────────────────────────────────────
+
+async function runPositive(entry: PositiveEntry): Promise<PositiveResult> {
+  try {
+    const result = await decodeGrid({ grid: entry.grid });
+    const decodedText = result.payload.text;
+    const passed = decodedText === entry.message;
+    return { entry, passed, decodedText, error: null };
+  } catch (error) {
+    return {
+      entry,
+      passed: false,
+      decodedText: null,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function runNegative(entry: NegativeEntry): Promise<NegativeResult> {
+  try {
+    const result = await decodeGrid({ grid: entry.grid });
+    return { entry, falsePositive: true, decodedText: result.payload.text };
+  } catch {
+    return { entry, falsePositive: false, decodedText: null };
+  }
+}
+
+export async function runBenchmark(): Promise<BenchmarkResult> {
+  const corpus = {
+    positives: generatePositiveCorpus(),
+    negatives: generateNegativeCorpus(),
+  };
+
+  console.log(
+    `Running benchmark: ${corpus.positives.length} positives, ${corpus.negatives.length} negatives`,
+  );
+
+  const positiveResults = await Promise.all(corpus.positives.map(runPositive));
+  const negativeResults = await Promise.all(corpus.negatives.map(runNegative));
+
+  const decodeSuccesses = positiveResults.filter((r) => r.passed).length;
+  const decodeFailures = positiveResults.length - decodeSuccesses;
+  const falsePositives = negativeResults.filter((r) => r.falsePositive).length;
+
+  return {
+    positives: positiveResults,
+    negatives: negativeResults,
+    decodeSuccesses,
+    decodeFailures,
+    falsePositives,
+    decodeRate: positiveResults.length > 0 ? decodeSuccesses / positiveResults.length : 0,
+    falsePositiveRate: negativeResults.length > 0 ? falsePositives / negativeResults.length : 0,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "typecheck": "tsc --noEmit",
     "package:quality": "bun run build && publint && attw --pack .",
     "changeset:version": "changeset version",
-    "changeset:publish": "changeset publish"
+    "changeset:publish": "changeset publish",
+    "benchmark": "bun run benchmark/cli.ts"
   },
   "dependencies": {
     "effect": "^4.0.0-beta.43"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,6 @@
     "noEmit": true,
     "types": ["bun-types"]
   },
-  "include": ["src", "test", "tests", "*.ts", "*.mts"],
+  "include": ["src", "test", "tests", "benchmark", "*.ts", "*.mts"],
   "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
## Closes #9

### What's in this PR

Implements a synthetic benchmark harness that stress-tests the `decodeGrid` API across the full QR version/ECL/mask space and measures decode quality.

**Positive corpus (45 entries)**
- v1 × {L, M, Q, H} × all 8 mask patterns = 32 entries
- v7, v20, v40 × {L, M, Q, H} at mask 0 = 12 entries
- RS error-correction fixture: v1-M with 4 deliberately corrupted data codewords (t=5, well within correction capacity) = 1 entry

**Negative corpus (13 entries)**
- 6 pure random-noise grids at QR-like sizes (v1=21×21 through v40=177×177)
- 4 scrambled-data grids (valid function modules, randomised data modules)
- 3 near-miss format-info grids (correct QR structure, both format-info copies overwritten with a value guaranteed to be Hamming-distance >3 from every valid pattern)

The adversarial format-info value is found at startup by searching the 15-bit space for a word at distance >3 from all 32 valid BCH(15,5) codewords — verified to exist since ≈14k of the 32k words are outside every correction ball.

### Acceptance criteria
- [x] bun run benchmark runs to completion and writes benchmark-results.json.
- [x] Positive corpus covers versions 1, 7, 20, 40 across all 4 EC levels and all 8 mask patterns for v1.
- [x] Negative corpus includes random noise, scrambled data, and near-miss format-info grids; false positives tracked in report.
- [x] An RS error-correction case is included: at least one fixture with deliberately corrupted bits.
- [x] Report is machine-readable JSON with decodeRate and falsePositiveRate as top-level numeric fields.
- [x] benchmark-results.json is added to .gitignore.

### Sample output
```
Running benchmark: 45 positives, 13 negatives

── Benchmark Results ──────────────────────────────────
  Positives : 45/45 passed  (decodeRate 100.0%)
  Negatives : 0 false positives out of 13  (falsePositiveRate 0.0%)
```